### PR TITLE
Dependencies updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # Create intermediary builder image.
-FROM debian:bullseye AS builder
+FROM debian:trixie AS builder
 
 # Install build dependencies.
 RUN apt-get update && \
@@ -35,19 +35,19 @@ COPY . /biostools
 
 # Compile bios_extract.
 RUN cd /biostools/bios_extract && \
-	make
+	make -j `nproc`
 
 # Compile deark.
 RUN cd /biostools/deark && \
-	make
+	make -j `nproc`
 
 # Create final image.
-FROM debian:bullseye
+FROM debian:trixie
 
 # Install runtime dependencies.
-RUN sed -i -e 's/main/main contrib non-free/' /etc/apt/sources.list && \
+RUN sed -i -e 's/Components: main/Components: main contrib non-free/' /etc/apt/sources.list.d/debian.sources &&\
 	apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip p7zip-full p7zip-rar innoextract unshield qemu-system-x86 && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip pip p7zip-full p7zip-rar innoextract unshield qemu-system-i386 && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists
 
@@ -55,7 +55,7 @@ RUN sed -i -e 's/main/main contrib non-free/' /etc/apt/sources.list && \
 COPY --from=builder /biostools /biostools
 
 # Install Python dependencies.
-RUN pip install -r /biostools/requirements.txt
+RUN	pip install --break-system-packages -r /biostools/requirements.txt 
 
 # Establish directories.
 VOLUME /bios

--- a/biostools/analyzers.py
+++ b/biostools/analyzers.py
@@ -288,7 +288,7 @@ class AcerMultitechAnalyzer(Analyzer):
 		super().__init__('AcerMultitech', *args, **kwargs)
 		self.vendor = 'Acer'
 
-		self._version_pattern = re.compile(b'''Multitech Industrial Corp\..BIOS ([^\s]+ [^\s\\x00]+)''')
+		self._version_pattern = re.compile(br'''Multitech Industrial Corp\..BIOS ([^\s]+ [^\s\\x00]+)''')
 
 	def can_handle(self, file_path, file_data, header_data):
 		# Look for version and date.
@@ -1671,8 +1671,8 @@ class GeneralSoftwareAnalyzer(Analyzer):
 	def __init__(self, *args, **kwargs):
 		super().__init__('General', *args, **kwargs)
 
-		self._string_pattern = re.compile(b'''([0-9]{2}/[0-9]{2}/[0-9]{2})\(C\) [0-9]+ General Software, Inc\. ''')
-		self._version_pattern = re.compile(b'''General Software (?:\\x00 )?([^\\\\\\x0D\\x0A]+)(?:rel\.|Revision)''')
+		self._string_pattern = re.compile(br'''([0-9]{2}/[0-9]{2}/[0-9]{2})\(C\) [0-9]+ General Software, Inc\. ''')
+		self._version_pattern = re.compile(br'''General Software (?:\\x00 )?([^\\\\\\x0D\\x0A]+)(?:rel\.|Revision)''')
 
 	def can_handle(self, file_path, file_data, header_data):
 		# Extract version.
@@ -1994,7 +1994,7 @@ class OlivettiAnalyzer(Analyzer):
 	def __init__(self, *args, **kwargs):
 		super().__init__('Olivetti', *args, **kwargs)
 
-		self._version_pattern = re.compile('''Version ([^\s]+)''')
+		self._version_pattern = re.compile(r'''Version ([^\s]+)''')
 
 		self.register_check_list([
 			((self._version_precheck, self._version),		AlwaysRunChecker),
@@ -2029,7 +2029,7 @@ class OlivettiAnalyzer(Analyzer):
 		return True
 
 	def _string_date(self, line, match):
-		'''^(?:COPYRIGHT \(C\) OLIVETTI )?([0-9]{2}/[0-9]{2}/[0-9]{2})$'''
+		r'''^(?:COPYRIGHT \(C\) OLIVETTI )?([0-9]{2}/[0-9]{2}/[0-9]{2})$'''
 
 		# Extract the date as a string if newer than any previously-found date.
 		date = match.group(1)

--- a/biostools/analyzers.py
+++ b/biostools/analyzers.py
@@ -132,7 +132,7 @@ class Analyzer:
 		"""Returns True if the given file's strings should be analyzed."""
 		return len(self._check_list) > 0
 
-	def can_handle(self, file_path, file_data, header_data):
+	def can_handle(self, file_path, file_data, header_data) -> bool:
 		"""Returns True if this analyzer can handle the given file data.
 		   header_data contains data from the :header: flag file, or
 		   None if no such file exists."""

--- a/biostools/formatters.py
+++ b/biostools/formatters.py
@@ -56,7 +56,7 @@ class Formatter:
 
 		# Encode the URL.
 		link_url = link_url.replace('#', '%23')
-		link_url = re.sub('''\?(^[/]*)/''', '%3F\\1/', link_url)
+		link_url = re.sub(r'''\?(^[/]*)/''', '%3F\\1/', link_url)
 
 		# Stop if the URL is not valid.
 		slash_index = link_url.find('/')

--- a/biostools/pciutil.py
+++ b/biostools/pciutil.py
@@ -19,16 +19,16 @@ import io, re, urllib.request
 
 clean_device_abbr = [
 	# Generic patterns to catch extended abbreviations: "Abbreviated Terms (AT)"
-	('([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3(?:$|\)|\]|\})', '\\2\\3'),
-	('([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3\\4(?:$|\)|\]|\})', '\\2\\3\\4'),
-	('([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3\\4\\5(?:$|\)|\]|\})', '\\2\\3\\4\\5'),
+	(r'([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3(?:$|\)|\]|\})', '\\2\\3'),
+	(r'([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3\\4(?:$|\)|\]|\})', '\\2\\3\\4'),
+	(r'([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^- ]+[- ]([A-Z])[^ ]+ (?:\(|\[|\{|/)\\2\\3\\4\\5(?:$|\)|\]|\})', '\\2\\3\\4\\5'),
 
 	# Manual patterns
 	('100Base-TX?', 'FE'),
 	('1000Base-T', 'GbE'),
 	('Accelerat(?:ion|or)', 'Accel.'),
 	('Alert on LAN', 'AoL'),
-	('\((.+) applications?\)', '(\\2)'), # 8086:105e
+	(r'\((.+) applications?\)', '(\\2)'), # 8086:105e
 	('Chipset Family', 'Chipset'),
 	('Chipset Graphics', 'iGPU'),
 	('Connection', 'Conn.'),
@@ -70,12 +70,12 @@ clean_device_abbr = [
 	('Wireless LAN', 'WLAN'),
 
 	# Generic pattern to remove duplicate abbreviations: "AT (AT)"
-	('([^ \(\[\{/]+) (?: |\(|\[|\{|/)\\2(?: |\)|\]|\})', '\\2'),
+	(r'([^ \(\[\{/]+) (?: |\(|\[|\{|/)\\2(?: |\)|\]|\})', '\\2'),
 ]
-clean_device_bit_pattern = re.compile('''( |^|\(|\[|\{|/)(?:([0-9]{1,4}) )?(?:(K)(?:ilo)?|(M)(?:ega)?|(G)(?:iga)?)bit( |$|\)|\]|\})''', re.I)
-clean_device_suffix_pattern = re.compile(''' (?:Adapter|Card|Device|(?:Host )?Controller)( (?: [0-9#]+)?|$|\)|\]|\})''', re.I)
-clean_vendor_abbr_pattern = re.compile(''' \[([^\]]+)\]''')
-clean_vendor_suffix_pattern = re.compile('''[ ,.](?:Semiconductors?|(?:Micro)?electronics?|Interactive|Technolog(?:y|ies)|(?:Micro)?systems|Computer(?: works)?|Products|Group|and subsidiaries|of(?: America)?|Co(?:rp(?:oration)?|mpany)?|Inc|LLC|Ltd|GmbH(?: & .+)?|AB|AG|SA|(?:\(|\[|\{).*)$''', re.I)
+clean_device_bit_pattern = re.compile(r'''( |^|\(|\[|\{|/)(?:([0-9]{1,4}) )?(?:(K)(?:ilo)?|(M)(?:ega)?|(G)(?:iga)?)bit( |$|\)|\]|\})''', re.I)
+clean_device_suffix_pattern = re.compile(r''' (?:Adapter|Card|Device|(?:Host )?Controller)( (?: [0-9#]+)?|$|\)|\]|\})''', re.I)
+clean_vendor_abbr_pattern = re.compile(r''' \[([^\]]+)\]''')
+clean_vendor_suffix_pattern = re.compile(r'''[ ,.](?:Semiconductors?|(?:Micro)?electronics?|Interactive|Technolog(?:y|ies)|(?:Micro)?systems|Computer(?: works)?|Products|Group|and subsidiaries|of(?: America)?|Co(?:rp(?:oration)?|mpany)?|Inc|LLC|Ltd|GmbH(?: & .+)?|AB|AG|SA|(?:\(|\[|\{).*)$''', re.I)
 clean_vendor_force = {
 	'National Semiconductor Corporation': 'NSC',
 }
@@ -108,7 +108,7 @@ def clean_device(device, vendor=None):
 	if not _clean_device_abbr_cache:
 		for pattern, replace in clean_device_abbr:
 			_clean_device_abbr_cache.append((
-				re.compile('''(?P<prefix> |^|\(|\[|\{|/)''' + pattern + '''(?P<suffix> |$|\)|\]|\})''', re.I),
+				re.compile(r'''(?P<prefix> |^|\(|\[|\{|/)''' + pattern + r'''(?P<suffix> |$|\)|\]|\})''', re.I),
 				'\\g<prefix>' + replace + '\\g<suffix>',
 			))
 

--- a/biostools/pciutil.py
+++ b/biostools/pciutil.py
@@ -45,7 +45,7 @@ clean_device_abbr = [
 	('Host Bus Adapter', 'HBA'),
 	('Host[- ]Controller', 'HC'), # dash = 1106:3104
 	('Input/Output', 'I/O'),
-	('Integrated ([^\s]+) (?:Graphics|GPU)', '\\2 iGPU'), # VIA CLE266
+	(r'Integrated ([^\s]+) (?:Graphics|GPU)', '\\2 iGPU'), # VIA CLE266
 	('Integrated (?:Graphics|GPU)', 'iGPU'),
 	('([0-9]) (lane|port)', '\\2-\\3'),
 	('Local Area Network', 'LAN'),

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,11 +19,11 @@
 # Skip extractor if the 0 directory exists and there's no 1 directory to append.
 if [ ! -d /bios/0 -o -d /bios/1 ]
 then
-	# Run extractor.
-	python3 -u -m biostools -x /bios $* >&2
-
 	# Print usage if there's no 1 directory (nothing bound to /bios).
 	[ ! -d /bios/1 ] && exec python3 -u -m biostools --docker-usage >&2
+
+	# Run extractor.
+	python3 -u -m biostools -x /bios $* >&2
 
 	# Fail if there's no 0 directory.
 	[ ! -d /bios/0 ] && exit 1


### PR DESCRIPTION
This updates the dependency in the docker image from debian 11 to debian 13.
It changes the way python packages are being installed and also changes the way some strings are handled by python, so I had to update these as well.

I also noticed an issue with the entrypoint when no ROM was given to the CLI, instead of using the safeguard that shows the usage, it would instead run the command first, which empties the ROM folder, and causes the safeguard to always show up, so I changed the order.